### PR TITLE
Add possibility to set content type to tvshows

### DIFF
--- a/ardundzdf.py
+++ b/ardundzdf.py
@@ -319,6 +319,9 @@ PLog("skindir: %s" % skindir)
 if 'confluence' in skindir:									# ermöglicht Plot-Infos in Medienansicht
 	xbmcplugin.setContent(HANDLE, 'movies')	
 
+if SETTINGS.getSetting('pref_content_type_tvshows') == 'true':
+	xbmcplugin.setContent(HANDLE, 'tvshows')
+
 ARDSender = ['ARD-Alle:ard::ard-mediathek.png:ARD-Alle']	# Rest in ARD_NEW, CurSenderZDF s. VerpasstWoche
 CurSender = ARDSender[0]									# Default ARD-Alle
 fname = os.path.join(DICTSTORE, 'CurSender')				# init CurSender (aktueller Sender)

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -112,7 +112,10 @@
   	<setting label="Slideshow für Musik-Player: " type="select" id="pref_musicslideshow" default="Keine"
    		values="Keine|Kodi <Bild-Steuerung>|Addon <Player-Steuerung und Musikinfos>"/>
 	<setting label="Slideshow für Musik-Player: Verzeichnis wählen" type="folder" source="" id="pref_slides_path" default=""/>
-	<setting label="Slideshow für Musik-Player: Anzeigedauer in Sekunden" type="select" id="pref_slides_time" default="10" values="5|10|15|20|30|60|120|240|600"/></category>
+	<setting label="Slideshow für Musik-Player: Anzeigedauer in Sekunden" type="select" id="pref_slides_time" default="10" values="5|10|15|20|30|60|120|240|600"/>
+    <setting type="sep"/>
+  	<setting label="Setze Inhaltstyp TV-Shows" type="bool" id="pref_content_type_tvshows" default="false"/>
+</category>
 </settings>
 
 


### PR DESCRIPTION
With the default skin Estuary the watched state of videos is currently not shown. Instead of the checkmark the thumbnail of the video is shown. This PR adds a toggle for setting the content type to "tvshows". Afterwards the default view for tvshows is applied and already watched videos are marked.