### PR TITLE
ZDF uses semicolon in video description; bug with python2

### DIFF
--- a/ardundzdf.py
+++ b/ardundzdf.py
@@ -6905,8 +6905,8 @@ def ZDF_PageMenu(DictID,  jsonObject="", urlkey="", mark="", li="", homeID=""):
 			PLog("Satz1_1:")
 			PLog(stage); PLog(typ); PLog(title);
 			title = repl_json_chars(title)
-			descr = repl_json_chars(descr)
 			tag = repl_json_chars(tag)
+			descr = repl_json_chars(descr); descr=descr.replace(';','.')
 			if entry["type"]=="video":								# Videos
 				if "channel" in entry:								# Zusatz Sender
 					sender = entry["channel"]


### PR DESCRIPTION
ZDF uses semicolon in video description. The description is added with other parameters into an URL. When parsing and spliting the URL in python2 the semicolon is used as a separator which leads to a wrong data in the resulting dictionary and video cannot be found by video player.

Semicolon is replaced by "." instead and everything works again in python2